### PR TITLE
Build with 256 color support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ fi
 set -e
 cd src
 ./autogen.sh
-./configure --prefix=/usr/local
+./configure --prefix=/usr/local --enable-colors256
 make
 
 echo ""


### PR DESCRIPTION
Passing the flag allows screen to build in 256 color mode, instead of the default 16 color mode. It's pretty nice for Emacs.
